### PR TITLE
Improve how libraries are located and various cleanup

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,43 @@
+name: 'Compile'
+permissions: {}
+on: [push, pull_request]
+jobs:
+  main:
+    name: 'Compile'
+#   runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+#       os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs:
+          - 28.1
+          - 29.4
+          - release-snapshot
+          - snapshot
+    steps:
+      - name: 'Install Emacs'
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs }}
+      - name: 'Install dependencies'
+        run: |
+          sudo apt-get install build-essential libffi-dev libltdl-dev
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: 'Compile module'
+        run: |
+          make module
+      - name: 'Compile lisp'
+        run: |
+          make lisp
+      - name: 'Compile lisp (byte-compile-error-on-warn)'
+#       if: ${{ vars.byte_compile_error_on_warn != 'nil' }}
+        run: |
+          make EMACS_ARGS="--eval '(progn \
+          (setq byte-compile-error-on-warn t) \
+          ${{ vars.compile_error_settings }})'" redo-lisp
+#     - name: 'Test'

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,88 @@
-# Makefile for FFI module.
-
-# This is is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-
-# This is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-
-# You should have received a copy of the GNU General Public License
-# along with this.  If not, see <https://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 -include config.mk
 
-# Where your dynamic-module-enabled Emacs build lies.
-EMACS_BUILDDIR ?= /home/tromey/Emacs/emacs
+# Set this to debug make test.
+# GDB = gdb --args
 
-LDFLAGS = -shared
-LIBS = -lffi -lltdl
-CFLAGS += -g3 -Og -finline-small-functions -shared -fPIC \
+# FIXME Emacs (what release?) now installs the necessary headers
+# so this shouldn't be required anymore.
+# EMACS_BUILDDIR ?= /home/tromey/Emacs/emacs
+EMACS_BUILDDIR ?= /home/jonas/src/emacs/emacs/master
+
+PKG = ffi
+
+ELS   = ffi.el
+ELS  += test.el
+ELCS  = $(ELS:.el=.elc)
+
+EMACS      ?= emacs
+EMACS_ARGS ?=
+LOAD_PATH   = -L .
+
+LDFLAGS  = -shared
+LIBS     = -lffi -lltdl
+CFLAGS  += -g3 -Og -finline-small-functions -shared -fPIC \
   -I$(EMACS_BUILDDIR)/src/ -I$(EMACS_BUILDDIR)/lib/
 
-# Set this to debug make check.
-#GDB = gdb --args
+all: module test-module lisp
 
-all: module test-module
+help:
+	$(info make all          - build module and lisp)
+	$(info make redo         - re-build module and lisp)
+	$(info make module       - build module)
+	$(info make test-module  - build test module)
+	$(info make lisp         - build lisp and autoloads)
+	$(info make test         - run tests)
+	$(info make clean        - remove generated files)
+	@printf "\n"
+
+redo: clean all
 
 module: ffi-module.so
+
+test-module: test.so
+
+lisp: $(ELCS) loaddefs
+
+test: ffi-module.so test.so $(ELCS)
+	LD_LIBRARY_PATH=`pwd`:$$LD_LIBRARY_PATH; \
+	  export LD_LIBRARY_PATH; \
+	$(GDB) $(EMACS_BUILDDIR)/src/emacs -batch -L `pwd` -l ert -l test.el \
+	  -f ert-run-tests-batch-and-exit
+
+clean:
+	@printf " Cleaning *...\n"
+	@rm -rf $(ELCS) $(PKG)-autoloads.el *.o *.so
+
 
 ffi-module.so: ffi-module.o
 	$(CC) $(LDFLAGS) -o ffi-module.so ffi-module.o $(LIBS)
 
 ffi-module.o: ffi-module.c
 
-check: ffi-module.so test.so
-	LD_LIBRARY_PATH=`pwd`:$$LD_LIBRARY_PATH; \
-	  export LD_LIBRARY_PATH; \
-	$(GDB) $(EMACS_BUILDDIR)/src/emacs -batch -L `pwd` -l ert -l test.el \
-	  -f ert-run-tests-batch-and-exit
-
-test-module: test.so
-
 test.so: test.o
 	$(CC) $(LDFLAGS) -o test.so test.o
 
-test.o: test.c
+test.o: test.c ffi-module.c
 
-clean:
-	-rm -f ffi.elc ffi-autoloads.el ffi-module.o ffi-module.so
-	-rm -f test.o test.so
+loaddefs: $(PKG)-autoloads.el
+
+%.elc: %.el
+	@printf "Compiling $<\n"
+	@$(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH) -f batch-byte-compile $<
+
+$(PKG)-autoloads.el: $(ELS)
+	@printf " Creating $@\n"
+	@$(EMACS) -Q --batch -l autoload -l cl-lib --eval "\
+(let ((file (expand-file-name \"$@\"))\
+      (autoload-timestamps nil) \
+      (backup-inhibited t)\
+      (version-control 'never)\
+      (coding-system-for-write 'utf-8-emacs-unix))\
+  (write-region (autoload-rubric file \"package\" nil) nil file nil 'silent)\
+  (cl-letf (((symbol-function 'progress-reporter-do-update) (lambda (&rest _)))\
+            ((symbol-function 'progress-reporter-done) (lambda (_))))\
+    (let ((generated-autoload-file file))\
+      (update-directory-autoloads default-directory))))" \
+	2>&1 | sed "/^Package autoload is deprecated$$/d"

--- a/ffi-module.c
+++ b/ffi-module.c
@@ -19,6 +19,7 @@ along with this.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <ltdl.h>
 #include <string.h>
 #include <assert.h>
+#include <stdbool.h>
 
 // Emacs got rid of this typedef, but it is still handy.
 typedef void (*emacs_finalizer_function) (void *);
@@ -1003,6 +1004,8 @@ init_type_alias (const char *name, bool is_unsigned, int size)
     type_descriptors[i].type = type;
 }
 
+static bool initialized = false;
+
 #define INIT_TYPE_ALIAS(Type)					\
   do								\
     {								\
@@ -1014,6 +1017,9 @@ init_type_alias (const char *name, bool is_unsigned, int size)
 int
 emacs_module_init (struct emacs_runtime *runtime)
 {
+  if (initialized)
+    return 0;
+
   unsigned int i;
   emacs_env *env = runtime->get_environment (runtime);
 
@@ -1063,5 +1069,6 @@ emacs_module_init (struct emacs_runtime *runtime)
 	return -1;
     }
 
+  initialized = true;
   return 0;
 }

--- a/ffi-module.c
+++ b/ffi-module.c
@@ -13,6 +13,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this.  If not, see <https://www.gnu.org/licenses/>.  */
 
+#include <config.h>
 #include "emacs-module.h"
 
 #include <ffi.h>

--- a/ffi.el
+++ b/ffi.el
@@ -43,17 +43,18 @@
   (declare (indent defun))
   ;; Turn variable references into actual types; while keeping keywords
   ;; the same.
-  (let* ((arg-names (mapcar (lambda (_) (cl-gensym)) arg-types))
+  (let* ((n 0)
+         (args (mapcar (lambda (_) (intern (format "arg%d" (cl-incf n)))) arg-types))
          (arg-types (vconcat (mapcar #'symbol-value arg-types)))
          (sym (intern (concat "ffi-fun-" c-name)))
          (cif (ffi--prep-cif (symbol-value return-type) arg-types)))
     `(progn
        (defvar ,sym nil)
-       (defun ,name (,@arg-names)
+       (defun ,name (,@args)
          (unless ,sym
            (setq ,sym (ffi--dlsym ,c-name (,library))))
          ;; FIXME do we even need a separate prep?
-         (ffi--call ,cif ,sym ,@arg-names)))))
+         (ffi--call ,cif ,sym ,@args)))))
 
 (defun ffi-lambda (function-pointer return-type arg-types)
   (let ((cif (ffi--prep-cif return-type (vconcat arg-types))))

--- a/ffi.el
+++ b/ffi.el
@@ -76,32 +76,28 @@
 
 (defun ffi--struct-union-helper (name slots definer-function layout-function)
   (cl-assert (symbolp name))
-  (let* ((docstring (if (stringp (car slots))
-                        (pop slots)))
-         (conc-name (concat (symbol-name name) "-"))
-         (result-forms ())
+  (let* ((docstring (and (stringp (car slots))
+                         (pop slots)))
          (field-types (mapcar (lambda (slot)
                                 (cl-assert (eq (cadr slot) :type))
                                 (symbol-value (cl-caddr slot)))
                               slots))
          (field-offsets (funcall layout-function field-types)))
-    (push `(defvar ,name (apply #',definer-function ',field-types)
-             ,docstring)
-          result-forms)
-    (cl-mapc
-     (lambda (slot type offset)
-       (let ((getter-name (intern (concat conc-name
-                                          (symbol-name (car slot)))))
-             (offsetter (if (> offset 0)
-                            `(ffi-pointer+ object ,offset)
-                          'object)))
-         ;; One benefit of using defsubst here is that we don't have
-         ;; to provide a GV setter.
-         (push `(cl-defsubst ,getter-name (object)
-                  (ffi--mem-ref ,offsetter ,type))
-               result-forms)))
-     slots field-types field-offsets)
-    (cons 'progn (nreverse result-forms))))
+    `(progn
+       (defvar ,name
+         (apply #',definer-function ',field-types)
+         ,docstring)
+       ,@(cl-mapcar
+          (lambda (slot type offset)
+            (let ((getter-name (intern (format "%s-%s" name (car slot))))
+                  (offsetter (if (> offset 0)
+                                 `(ffi-pointer+ object ,offset)
+                               'object)))
+              ;; One benefit of using cl-defsubst here is that we don't
+              ;; have to provide a GV setter.
+              `(cl-defsubst ,getter-name (object)
+                 (ffi--mem-ref ,offsetter ,type))))
+          slots field-types field-offsets))))
 
 (defmacro define-ffi-struct (name &rest slots)
   "Like a limited form of `cl-defstruct', but works with foreign objects.

--- a/ffi.el
+++ b/ffi.el
@@ -41,11 +41,10 @@
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
   (declare (indent defun))
-  (let* (;; Turn variable references into actual types; while keeping
-         ;; keywords the same.
-         (arg-types (mapcar #'symbol-value arg-types))
-         (arg-names (mapcar (lambda (_ignore) (cl-gensym)) arg-types))
-         (arg-types (vconcat arg-types))
+  ;; Turn variable references into actual types; while keeping keywords
+  ;; the same.
+  (let* ((arg-names (mapcar (lambda (_) (cl-gensym)) arg-types))
+         (arg-types (vconcat (mapcar #'symbol-value arg-types)))
          (sym (intern (concat "ffi-fun-" c-name)))
          (cif (ffi--prep-cif (symbol-value return-type) arg-types)))
     `(progn

--- a/ffi.el
+++ b/ffi.el
@@ -28,7 +28,7 @@
 
 (require 'cl-macs)
 
-(eval-and-compile (module-load "ffi-module.so"))
+(eval-and-compile (module-load (locate-library "ffi-module")))
 
 (gv-define-simple-setter ffi--mem-ref ffi--mem-set t)
 
@@ -37,7 +37,7 @@
     (set library nil)
     `(defun ,symbol ()
        (or ,library
-           (setq ,library (ffi--dlopen ,name))))))
+           (setq ,library (ffi--dlopen (locate-library ,name)))))))
 
 (defmacro define-ffi-function (name c-name return-type arg-types library)
   (declare (indent defun))

--- a/ffi.el
+++ b/ffi.el
@@ -52,8 +52,9 @@
          (unless ,sym
            (setq ,sym (ffi--dlsym ,c-name (,library))))
          ;; FIXME do we even need a separate prep?
-         (ffi--call (ffi--prep-cif (symbol-value ,return-type)
-                                   ,(vconcat (mapcar #'symbol-value arg-types)))
+         (ffi--call (ffi--prep-cif ,return-type
+                                   (vconcat
+                                    (mapcar #'symbol-value ',arg-types)))
                     ,sym ,@args)))))
 
 (defun ffi-lambda (function-pointer return-type arg-types)

--- a/ffi.el
+++ b/ffi.el
@@ -66,12 +66,10 @@
 
 (defun ffi--lay-out-struct (types)
   (let ((offset 0))
-    (mapcar (lambda (this-type)
-              (setf offset (ffi--align offset
-                                       (ffi--type-alignment this-type)))
-              (let ((here offset))
-                (cl-incf offset (ffi--type-size this-type))
-                here))
+    (mapcar (lambda (type)
+              (prog1
+                  (setq offset (ffi--align offset (ffi--type-alignment type)))
+                (cl-incf offset (ffi--type-size type))))
             types)))
 
 (defun ffi--struct-union-helper (name slots definer-function layout-function)

--- a/ffi.el
+++ b/ffi.el
@@ -28,7 +28,7 @@
 
 (require 'cl-macs)
 
-(module-load "ffi-module.so")
+(eval-and-compile (module-load "ffi-module.so"))
 
 (gv-define-simple-setter ffi--mem-ref ffi--mem-set t)
 

--- a/test.el
+++ b/test.el
@@ -18,16 +18,16 @@
 (require 'ert)
 (require 'ffi)
 
-(define-ffi-library test.so "test")
+(define-ffi-library ffi-test "test")
 
-(define-ffi-function test-function "test_function" :int nil test.so)
-(define-ffi-function test-function-char "test_function" :char nil test.so)
+(define-ffi-function test-function "test_function" :int nil ffi-test)
+(define-ffi-function test-function-char "test_function" :char nil ffi-test)
 
 (ert-deftest ffi-basic ()
   (should (= (test-function) 27))
   (should (= (test-function-char) 27)))
 
-(define-ffi-function test-c-string "test_c_string" :pointer nil test.so)
+(define-ffi-function test-c-string "test_c_string" :pointer nil ffi-test)
 
 (ert-deftest ffi-pointer-type ()
   (should (eq (type-of (test-c-string)) 'user-ptr)))
@@ -39,14 +39,14 @@
   (1+ arg))
 
 (define-ffi-function test-call-callback "test_call_callback"
-  :int [:pointer] test.so)
+  :int [:pointer] ffi-test)
 
 (ert-deftest ffi-call-callback ()
   (let* ((cif (ffi--prep-cif :int [:int]))
          (pointer-to-callback (ffi-make-closure cif #'callback)))
     (should (eq (test-call-callback pointer-to-callback) 23))))
 
-(define-ffi-function test-add "test_add" :int [:int :int] test.so)
+(define-ffi-function test-add "test_add" :int [:int :int] ffi-test)
 
 (ert-deftest ffi-add ()
   (should (eq (test-add 23 -23) 0)))
@@ -75,7 +75,7 @@
   (intval :type :int))
 
 (define-ffi-function test-get-struct "test_get_struct"
-  test-struct nil test.so)
+  test-struct nil ffi-test)
 
 (ert-deftest ffi-structure-return ()
   (let ((struct-value (test-get-struct)))
@@ -84,7 +84,7 @@
     (should (eq (test-struct-intval struct-value) 23))))
 
 (define-ffi-function test-get-struct-int "test_get_struct_int"
-  :int (test-struct) test.so)
+  :int (test-struct) ffi-test)
 
 (ert-deftest ffi-struct-modification ()
   (let ((struct-value (test-get-struct)))
@@ -97,7 +97,7 @@
   (ival :type :int))
 
 (define-ffi-function test-get-union "test_get_union"
-  test-union nil test.so)
+  test-union nil ffi-test)
 
 (ert-deftest ffi-union ()
   (let ((object (test-get-union)))
@@ -107,7 +107,8 @@
 (ert-deftest ffi-null ()
   (should (ffi-pointer-null-p (ffi-null-pointer))))
 
-(define-ffi-function test-not "test_not" :bool (:bool) test.so)
+(define-ffi-function test-not "test_not"
+  :bool (:bool) ffi-test)
 
 (ert-deftest ffi-boolean ()
   (should (eq (test-not nil) t))
@@ -118,8 +119,8 @@
 (defconst test-user-defined-char :char)
 
 (ert-deftest ffi-array ()
-  (should (eq (define-ffi-array arr1 :char 1024) 'arr1))
-  (should (eq (define-ffi-array arr2 test-user-defined-char 1024) 'arr2)))
+  (should (eq (define-ffi-array test-arr1 :char 1024) 'test-arr1))
+  (should (eq (define-ffi-array test-arr2 test-user-defined-char 1024) 'test-arr2)))
 
 (ert-deftest ffi-with-ffi-multi-stat ()
   (should (eq (with-ffi-temporary (a :int) 1 2 3) 3))


### PR DESCRIPTION
This is the same as https://github.com/tromey/emacs-ffi/pull/21. Like that, this pr also includes the changes in https://github.com/tromey/emacs-ffi/pull/22.  Let me know whether you also want me to do multiple pull-requests.

I've improved one of the old commits ("Search for ffi-module on the load-path"):

- I'm not sure it is necessary to add the optional `nosuffix` and `path` arguments.  You might want to drop them and only add them we actually need them.  Currently this just mirrors `locate-library`, which might, or might not, be reason enough to add this here.

- It is necessary to load the module at compile-time as well.  Else the byte-compiler is very unhappy about all the unknown functions.

I've also added new commits:

- Consistently use spaces for indentation in `ffi.el`.

  That's the "new" convention for elisp.
  
  This causes conflicts with other prs, but I am going to resolve those in a bit.
  
  `ffi.c` should also be indented consistently.  I also recommend going with spaces.  If you decide to go with tabs instead, you would still have to make sure they are used consistently and you would have to set `tab-width` as a file-local variable, to ensure everyone uses the same setting.

- Addressed most of the compiler errors and warnings in `test.el`.

Some necessary things are not included:

- There are more serious issues the byte-compiler tells us about, but most of those are already addressed by https://github.com/tromey/emacs-ffi/pull/19.

- The C compiler pointed out that `config.h` has to be included, and doing that indeed makes the compilation succeed.  Someone else will have to figure out why that is, and document it in the commit message.

- You might want to start thinking about what Emacs releases you want to support and add CI to test on all of them.  You might want to do that before merging any prs.